### PR TITLE
feat: Replace hero image with auto-playing carousel

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,24 +1,52 @@
-import { useState, FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+import Autoplay from "embla-carousel-autoplay";
 
 const Hero = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const carouselImages = Array.from(
+    { length: 14 },
+    (_, i) => `/photohomepagecaroussel (${i + 1}).jpg`
+  );
+
   return (
     <div className="relative bg-estate-800 py-16 md:py-24 lg:py-32">
-      {/* Background Image with Overlay */}
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{
-          backgroundImage:
-            "url('https://images.unsplash.com/photo-1605146769289-440113cc3d00?auto=format&fit=crop&q=80&w=3270&ixlib=rb-4.0.3')",
-          opacity: "0.3",
+      <Carousel
+        opts={{
+          align: "start",
+          loop: true,
         }}
-      ></div>
+        plugins={[
+          Autoplay({
+            delay: 5000,
+          }),
+        ]}
+        className="absolute inset-0 w-full h-full"
+      >
+        <CarouselContent className="h-full">
+          {carouselImages.map((src, index) => (
+            <CarouselItem key={index} className="h-full">
+              <div
+                className="h-full bg-cover bg-center"
+                style={{
+                  backgroundImage: `url(${src})`,
+                }}
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <div className="absolute inset-0 bg-black opacity-30"></div> {/* Overlay */}
+      </Carousel>
 
       <div className="container relative z-10">
         <div className="text-center text-white max-w-4xl mx-auto">
@@ -39,8 +67,6 @@ const Hero = () => {
               {t('addListing')}
             </Button>
           </div>
-
-          
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replaces the static main image on the Home page (in the Hero component) with an image carousel.

Key changes:
- Integrated the `Carousel` component from `src/components/ui/carousel.tsx`.
- The carousel displays images named `photohomepagecaroussel (1).jpg` through `photohomepagecaroussel (14).jpg` from the `public` directory.
- Configured the carousel to autoplay with a 5-second delay and to loop continuously.
- Added a dark overlay (opacity 30%) on top of the carousel images to ensure the foreground text content remains legible.
- Ensured the carousel and its images are responsive, designed to cover the hero section area effectively across different screen sizes.

The implementation relies on `embla-carousel-react` and its `Autoplay` plugin. Static analysis and code review suggest the carousel functions as intended.