### PR TITLE
Fix: Ensure footer and property cards are in foreground

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = () => {
   const { t } = useTranslation();
 
   return (
-    <footer className="bg-estate-800 text-white">
+    <footer className="bg-estate-800 text-white relative z-20">
       <div className="container py-12 md:py-16">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10">
           {/* Company Info */}

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,7 @@
 
 @layer components {
   .property-card {
-    @apply transition-all duration-300 hover:shadow-lg hover:-translate-y-1;
+    @apply transition-all duration-300 hover:shadow-lg hover:-translate-y-1 relative z-20;
   }
 
   .btn-primary {


### PR DESCRIPTION
I've applied z-index adjustments to ensure that the website footer and property cards render above the background carousel image in the hero section.

Changes:
- Added `position: relative` and `z-index: 20` to the Footer component.
- Added `position: relative` and `z-index: 20` to the PropertyCard component's CSS.