### PR TITLE
feat: Improve manifest and favicon configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#0f766e" />
     <link rel="icon" href="/public/favicon.ico" type="image/x-icon" />
-    <link rel="apple-touch-icon" href="/public/georgiaflag.png" />
+    <link rel="apple-touch-icon" href="/public/apple-touch-icon.png" />
     <link rel="manifest" href="/public/manifest.json" />
     <link rel="canonical" href="https://househaven.ge/" />
     <link rel="alternate" href="https://househaven.ge/" hreflang="ka" />
@@ -23,7 +23,7 @@
     <meta property="og:title" content="უძრავი ქონება საქართველოში | House სახლი" />
     <meta property="og:description" content="იპოვეთ საუკეთესო უძრავი ქონება საქართველოში. ბინები, სახლები, კომერციული ფართები და მიწის ნაკვეთები ერთ სივრცეში." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/public/georgiaflag.png" />
+    <meta property="og:image" content="/public/apple-touch-icon.png" />
     <meta property="og:locale" content="ka_GE" />
     <meta property="og:url" content="https://househaven.ge/" />
 
@@ -32,7 +32,7 @@
     <meta name="twitter:site" content="@househaven_ge" />
     <meta name="twitter:title" content="უძრავი ქონება საქართველოში | House სახლი" />
     <meta name="twitter:description" content="იპოვეთ საუკეთესო უძრავი ქონება საქართველოში. ბინები, სახლები, კომერციული ფართები და მიწის ნაკვეთები ერთ სივრცეში." />
-    <meta name="twitter:image" content="/public/georgiaflag.png" />
+    <meta name="twitter:image" content="/public/apple-touch-icon.png" />
 
     <!-- Schema.org Structured Data -->
     <script type="application/ld+json">
@@ -41,7 +41,7 @@
         "@type": "RealEstateAgent",
         "name": "House სახლი",
         "url": "https://househaven.ge/",
-        "logo": "https://househaven.ge/public/georgiaflag.png",
+        "logo": "https://househaven.ge/public/apple-touch-icon.png",
         "description": "უძრავი ქონება საქართველოში - ბინები, სახლები, კომერციული ფართები და მიწის ნაკვეთები",
         "address": {
           "@type": "PostalAddress",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,8 +15,28 @@
       "type": "image/x-icon"
     },
     {
-      "src": "/public/georgiaflag.png",
-      "sizes": "192x192 512x512",
+      "src": "/public/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/public/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/public/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
+      "src": "/public/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/public/favicon-16x16.png",
+      "sizes": "16x16",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
Updates the manifest.json to include a more comprehensive set of icons, utilizing specific sizes for Android Chrome, Apple Touch, and standard favicons. This enhances your experience on various devices and improves PWA capabilities.

Changes made:
- Updated `public/manifest.json`:
    - Added entries for `android-chrome-192x192.png`, `android-chrome-512x512.png`, `apple-touch-icon.png`, `favicon-32x32.png`, and `favicon-16x16.png`.
    - Removed the generic `georgiaflag.png` from the icons list.
- Updated `index.html`:
    - Changed the `apple-touch-icon` link to point to `public/apple-touch-icon.png`.
    - Updated `og:image`, `twitter:image`, and Schema.org logo metadata to use `public/apple-touch-icon.png` for consistency and better presentation.

These changes contribute to better SEO, improved brand presentation across different platforms, and a more polished user experience when the site is added to a home screen or bookmarked.